### PR TITLE
使用cdn代替源url Fix #34

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ hosts 文件在每个系统的位置不一，详情如下：
 
 - Type: `Remote`
 
-- URL: `https://raw.githubusercontent.com/521xueweihan/GitHub520/main/hosts`
+- URL: `https://cdn.jsdelivr.net/gh/521xueweihan/GitHub520@main/hosts`
 
 - Auto Refresh: 最好选 `1 hour`
 
@@ -106,7 +106,7 @@ hosts 文件在每个系统的位置不一，详情如下：
 
 - 名称: 随意
 
-- URL: `https://raw.githubusercontent.com/521xueweihan/GitHub520/main/hosts`（和上面 SwitchHosts 使用的一样）
+- URL: `https://cdn.jsdelivr.net/gh/521xueweihan/GitHub520@main/hosts`（和上面 SwitchHosts 使用的一样）
 
 如图：
 

--- a/README_template.md
+++ b/README_template.md
@@ -62,7 +62,7 @@ hosts 文件在每个系统的位置不一，详情如下：
 
 - Type: `Remote`
 
-- URL: `https://raw.githubusercontent.com/521xueweihan/GitHub520/main/hosts`
+- URL: `https://cdn.jsdelivr.net/gh/521xueweihan/GitHub520@main/hosts`
 
 - Auto Refresh: 最好选 `1 hour`
 
@@ -78,7 +78,7 @@ hosts 文件在每个系统的位置不一，详情如下：
 
 - 名称: 随意
 
-- URL: `https://raw.githubusercontent.com/521xueweihan/GitHub520/main/hosts`（和上面 SwitchHosts 使用的一样）
+- URL: `https://cdn.jsdelivr.net/gh/521xueweihan/GitHub520@main/hosts`（和上面 SwitchHosts 使用的一样）
 
 如图：
 


### PR DESCRIPTION
- 使用cdn替代了源url以避免初次无法同步的情况