### PR TITLE
Update hosts

### DIFF
--- a/hosts
+++ b/hosts
@@ -1,3 +1,5 @@
+!Title: GitHub520
+!Homepage: https://github.com/521xueweihan/GitHub520
 # GitHub520 Host Start
 185.199.108.154               github.githubassets.com
 140.82.112.21                 central.github.com


### PR DESCRIPTION
能否像这样加上标题，在AdGuard中导入规则时才不会没有名字。