### PR TITLE
更新 readme 支持 Chrome 插件方式接入

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,10 @@ hosts 文件在每个系统的位置不一，详情如下：
 
 **Tip**：不要添加在 **DNS 允许清单** 内，只能添加在 **DNS 封锁清单** 才管用。另外，AdGuard for Mac、AdGuard for Windows、AdGuard for Android、AdGuard for IOS 等等 **AdGuard 家族软件** 添加方法均类似。
 
+### 2.4 Chrome 插件方式
+
+`FasterHosts` 是个 Chrome 插件，主要原理是拦截浏览器的某些请求，将 `domain` 替换成访问速度较快的那个。hosts 资源来自 [GitHub520](https://github.com/521xueweihan/GitHub520)，每 1 小时更新一次。
+
 ## 三、效果对比
 之前的样子：
 

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ hosts 文件在每个系统的位置不一，详情如下：
 > 1. 下载 [FasterHosts](https://github.com/gauseen/faster-hosts/archive/master.zip) 然后解压，找到 `extension` 子目录
 > 2. 打开 Chrome，输入: `chrome://extensions/`
 > 3. 打开「开发这模式」
-> 4. 选择「加载已解压的扩展程序」， 然后定位到刚才解压的文件夹里面的 `extension` 目录，确定
+> 4. 选择「加载已解压的扩展程序」，然后定位到刚才解压的文件夹里面的 `extension` 目录，确定
 > 5. 这就安装好了，关闭「开发这模式」
 
 ## 三、效果对比

--- a/README.md
+++ b/README.md
@@ -136,9 +136,9 @@ hosts 文件在每个系统的位置不一，详情如下：
 
 > 1. 下载 [FasterHosts](https://github.com/gauseen/faster-hosts/archive/master.zip) 然后解压，找到 `extension` 子目录
 > 2. 打开 Chrome，输入: `chrome://extensions/`
-> 3. 勾选 Developer Mode
-> 4. 选择 Load unpacked extension... 然后定位到刚才解压的文件夹里面的 chrome 目录，确定
-> 5. 这就安装好了，去掉 Developer Mode 勾选
+> 3. 打开「开发这模式」
+> 4. 选择「加载已解压的扩展程序」， 然后定位到刚才解压的文件夹里面的 `extension` 目录，确定
+> 5. 这就安装好了，关闭「开发这模式」
 
 ## 三、效果对比
 之前的样子：

--- a/README.md
+++ b/README.md
@@ -132,7 +132,13 @@ hosts 文件在每个系统的位置不一，详情如下：
 
 ### 2.4 Chrome 插件方式
 
-`FasterHosts` 是个 Chrome 插件，主要原理是拦截浏览器的某些请求，将 `domain` 替换成访问速度较快的那个。hosts 资源来自 [GitHub520](https://github.com/521xueweihan/GitHub520)，每 1 小时更新一次。
+[FasterHosts](https://github.com/gauseen/faster-hosts) 是个 Chrome 插件，主要原理是拦截浏览器的某些请求，将 `domain` 替换成访问速度较快的那个。hosts 资源来自 [GitHub520](https://github.com/521xueweihan/GitHub520)，每 1 小时更新一次。
+
+> 1. 下载 [FasterHosts](https://github.com/gauseen/faster-hosts/archive/master.zip) 然后解压，找到 `extension` 子目录
+> 2. 打开 Chrome，输入: `chrome://extensions/`
+> 3. 勾选 Developer Mode
+> 4. 选择 Load unpacked extension... 然后定位到刚才解压的文件夹里面的 chrome 目录，确定
+> 5. 这就安装好了，去掉 Developer Mode 勾选
 
 ## 三、效果对比
 之前的样子：

--- a/README.md
+++ b/README.md
@@ -33,10 +33,10 @@
 185.199.108.133               camo.githubusercontent.com
 185.199.108.133               github.map.fastly.net
 199.232.69.194                github.global.ssl.fastly.net
-140.82.112.4                  gist.github.com
+140.82.113.3                  gist.github.com
 185.199.108.153               github.io
-140.82.112.4                  github.com
-140.82.112.5                  api.github.com
+140.82.113.3                  github.com
+140.82.113.5                  api.github.com
 185.199.108.133               raw.githubusercontent.com
 185.199.108.133               user-images.githubusercontent.com
 185.199.108.133               favicons.githubusercontent.com
@@ -47,8 +47,8 @@
 185.199.108.133               avatars1.githubusercontent.com
 185.199.108.133               avatars0.githubusercontent.com
 185.199.108.133               avatars.githubusercontent.com
-140.82.114.10                 codeload.github.com
-52.216.239.187                github-cloud.s3.amazonaws.com
+140.82.114.9                  codeload.github.com
+52.217.76.132                 github-cloud.s3.amazonaws.com
 52.217.36.12                  github-com.s3.amazonaws.com
 52.216.95.67                  github-production-release-asset-2e65be.s3.amazonaws.com
 52.216.83.40                  github-production-user-asset-6210df.s3.amazonaws.com
@@ -58,13 +58,13 @@
 185.199.108.133               media.githubusercontent.com
 
 
-# Update time: 2021-05-18T14:05:15+08:00
+# Update time: 2021-05-18T16:05:16+08:00
 # Star me GitHub url: https://github.com/521xueweihan/GitHub520
 # GitHub520 Host End
 
 ```
 
-上面内容会自动定时更新，保证最新有效。数据更新时间：2021-05-18T14:05:15+08:00（内容无变动不会更新）
+上面内容会自动定时更新，保证最新有效。数据更新时间：2021-05-18T16:05:16+08:00（内容无变动不会更新）
 
 ### 2.1 手动方式
 #### 2.1.1 修改 hosts 文件

--- a/hosts
+++ b/hosts
@@ -8,10 +8,10 @@
 185.199.108.133               camo.githubusercontent.com
 185.199.108.133               github.map.fastly.net
 199.232.69.194                github.global.ssl.fastly.net
-140.82.112.4                  gist.github.com
+140.82.113.3                  gist.github.com
 185.199.108.153               github.io
-140.82.112.4                  github.com
-140.82.112.5                  api.github.com
+140.82.113.3                  github.com
+140.82.113.5                  api.github.com
 185.199.108.133               raw.githubusercontent.com
 185.199.108.133               user-images.githubusercontent.com
 185.199.108.133               favicons.githubusercontent.com
@@ -22,8 +22,8 @@
 185.199.108.133               avatars1.githubusercontent.com
 185.199.108.133               avatars0.githubusercontent.com
 185.199.108.133               avatars.githubusercontent.com
-140.82.114.10                 codeload.github.com
-52.216.239.187                github-cloud.s3.amazonaws.com
+140.82.114.9                  codeload.github.com
+52.217.76.132                 github-cloud.s3.amazonaws.com
 52.217.36.12                  github-com.s3.amazonaws.com
 52.216.95.67                  github-production-release-asset-2e65be.s3.amazonaws.com
 52.216.83.40                  github-production-user-asset-6210df.s3.amazonaws.com
@@ -33,6 +33,6 @@
 185.199.108.133               media.githubusercontent.com
 
 
-# Update time: 2021-05-18T14:05:15+08:00
+# Update time: 2021-05-18T16:05:16+08:00
 # Star me GitHub url: https://github.com/521xueweihan/GitHub520
 # GitHub520 Host End


### PR DESCRIPTION
### 支持 Chrome 插件方式接入

> 1. 下载 [FasterHosts](https://github.com/gauseen/faster-hosts/archive/master.zip) 然后解压，找到 `extension` 子目录
> 2. 打开 Chrome，输入: `chrome://extensions/`
> 3. 打开「开发这模式」
> 4. 选择「加载已解压的扩展程序」，然后定位到刚才解压的文件夹里面的 `extension` 目录，确定
> 5. 这样就安装好了，关闭「开发这模式」即可