### PR TITLE
Fix bug: 新旧host比对内容不对

### DIFF
--- a/fetch_ips.py
+++ b/fetch_ips.py
@@ -68,13 +68,15 @@ def write_file(hosts_content: str, update_time: str):
     template_path = os.path.join(os.path.dirname(__file__),
                                  "README_template.md")
     write_host_file(hosts_content)
-    with open(output_doc_file_path, "r") as old_readme_fb:
-        old_content = old_readme_fb.read()
-        old_hosts = old_content.split("```bash")[1].split("```")[0].strip()
-        old_hosts = old_hosts.split("# Update time:")[0]
-    if old_hosts == hosts_content:
-        print("host not change")
-        return False
+    if os.path.exists(output_doc_file_path):
+        with open(output_doc_file_path, "r") as old_readme_fb:
+            old_content = old_readme_fb.read()
+            old_hosts = old_content.split("```bash")[1].split("```")[0].strip()
+            old_hosts = old_hosts.split("# Update time:")[0].strip()
+            hosts_content_hosts = hosts_content.split("# Update time:")[0].strip()
+        if old_hosts == hosts_content_hosts:
+            print("host not change")
+            return False
 
     with open(template_path, "r") as temp_fb:
         template_str = temp_fb.read()


### PR DESCRIPTION
对源代码这里做了修改:

```python
if os.path.exists(output_doc_file_path):
        with open(output_doc_file_path, "r") as old_readme_fb:
            old_content = old_readme_fb.read()
            old_hosts = old_content.split("```bash")[1].split("```")[0].strip()
            old_hosts = old_hosts.split("# Update time:")[0].strip()    # 改动这里
            hosts_content_hosts = hosts_content.split("# Update time:")[0].strip()    # 改动这里
        if old_hosts == hosts_content_hosts:  # 改动这里
            print("host not change")
            return False
```

原代码没有对 `hosts_content` 做的 `# Update time:` 的切片处理「因为hosts_content包含# Update time:这一部分的」，导致即使hosts没有更新，也无法做 `old_hosts` 与 `hosts_content` 比对。 