### PR TITLE
Update BSD/macOS one-line command

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ hosts 文件在每个系统的位置不一，详情如下：
 
 #### BSD/macOS
 
-`sed -i "" "/# GitHub520 Host Start/,/# Github520 Host End/d" /etc/hosts && curl https://raw.hellogithub.com/hosts >> /etc/hosts`
+`sudo sed -i "" "/# GitHub520 Host Start/,/# Github520 Host End/d" /etc/hosts && curl https://raw.hellogithub.com/hosts | sudo tee -a /etc/hosts`
 
 将上面的命令添加到 cron，可定时执行。使用前确保 GitHub520 内容在该文件最后部分。
 


### PR DESCRIPTION
同上面 GNU (Ubuntu/CentOS/Fedora) 行, 给 BSD/macOS 上的命名也添加上 sudo, 并把写入 hosts 动作单独出来, 因为旧的 `>>` 隐式 `echo` 的动作里不方便添加 sudo.