### PR TITLE
Update datetime.datetime.utcnow() in fetch_ips.py

### DIFF
--- a/fetch_ips.py
+++ b/fetch_ips.py
@@ -157,7 +157,7 @@ def main(verbose=False) -> None:
 
     if not content:
         return
-    update_time = datetime.utcnow().astimezone(
+    update_time = datetime.now(timezone.utc).astimezone(
         timezone(timedelta(hours=8))).replace(microsecond=0).isoformat()
     hosts_content = HOSTS_TEMPLATE.format(content=content,
                                           update_time=update_time)


### PR DESCRIPTION
修复以下问题：
弃用警告：datetime.datetime.utcnow() 已弃用，计划在未来版本中删除。使用时区感知对象以 UTC 表示日期时间：datetime.datetime.now(datetime.UTC)。