### PR TITLE
fix: reject invalid hosts payloads before publishing

### DIFF
--- a/common.py
+++ b/common.py
@@ -7,6 +7,7 @@
 #   Desc    :   公共函数
 import os
 import json
+import ipaddress
 from typing import Any, Optional
 from datetime import datetime, timezone, timedelta
 
@@ -40,6 +41,39 @@ HOSTS_TEMPLATE = """# GitHub520 Host Start
 # Update url: https://raw.hellogithub.com/hosts
 # Star me: https://github.com/521xueweihan/GitHub520
 # GitHub520 Host End\n"""
+
+
+def validate_hosts_list(content_list: list) -> None:
+    """Reject incomplete or unsafe DNS results before publishing any files."""
+    expected_hosts = set(GITHUB_URLS)
+    if len(content_list) != len(GITHUB_URLS):
+        raise ValueError(
+            f"expected {len(GITHUB_URLS)} host mappings, got {len(content_list)}")
+
+    seen_hosts = set()
+    invalid_entries = []
+    for entry in content_list:
+        if not isinstance(entry, (list, tuple)) or len(entry) != 2:
+            invalid_entries.append(entry)
+            continue
+        ip, hostname = entry
+        try:
+            if ipaddress.ip_address(ip).version != 4:
+                invalid_entries.append(entry)
+                continue
+        except (TypeError, ValueError):
+            invalid_entries.append(entry)
+            continue
+        if hostname not in expected_hosts or hostname in seen_hosts:
+            invalid_entries.append(entry)
+            continue
+        seen_hosts.add(hostname)
+
+    if invalid_entries or seen_hosts != expected_hosts:
+        missing_hosts = sorted(expected_hosts - seen_hosts)
+        raise ValueError(
+            f"invalid host mappings: {invalid_entries}; "
+            f"missing hosts: {missing_hosts}")
 
 
 @retry(tries=3)
@@ -94,7 +128,8 @@ def write_json_file(hosts_list: list) -> None:
 
 def write_hosts_content(content: str, content_list: list) -> str:
     if not content:
-        return ""
+        raise ValueError("refusing to publish an empty hosts payload")
+    validate_hosts_list(content_list)
     update_time = datetime.now(timezone.utc).astimezone(
         timezone(timedelta(hours=8))).replace(microsecond=0).isoformat()
     hosts_content = HOSTS_TEMPLATE.format(content=content,

--- a/tests/test_hosts_payload_validation.py
+++ b/tests/test_hosts_payload_validation.py
@@ -1,0 +1,50 @@
+import unittest
+from unittest.mock import patch
+
+import common
+
+
+def complete_payload():
+    return [(f"192.0.2.{index + 1}", hostname)
+            for index, hostname in enumerate(common.GITHUB_URLS)]
+
+
+class HostsPayloadValidationTest(unittest.TestCase):
+    def assert_rejected_without_writing(self, content_list):
+        with patch("common.write_file") as write_file:
+            with self.assertRaises(ValueError):
+                common.write_hosts_content("payload", content_list)
+        write_file.assert_not_called()
+
+    def test_accepts_complete_ipv4_payload(self):
+        with patch("common.write_file", return_value=False):
+            result = common.write_hosts_content("payload", complete_payload())
+        self.assertIn("# GitHub520 Host Start", result)
+
+    def test_rejects_empty_payload(self):
+        with patch("common.write_file") as write_file:
+            with self.assertRaises(ValueError):
+                common.write_hosts_content("", complete_payload())
+        write_file.assert_not_called()
+
+    def test_rejects_missing_host(self):
+        self.assert_rejected_without_writing(complete_payload()[:-1])
+
+    def test_rejects_duplicate_host(self):
+        payload = complete_payload()
+        payload[-1] = payload[0]
+        self.assert_rejected_without_writing(payload)
+
+    def test_rejects_dns_failure_sentinel(self):
+        payload = complete_payload()
+        payload[0] = ("# IP Address Not Found", common.GITHUB_URLS[0])
+        self.assert_rejected_without_writing(payload)
+
+    def test_rejects_ipv6_mapping(self):
+        payload = complete_payload()
+        payload[0] = ("2001:db8::1", common.GITHUB_URLS[0])
+        self.assert_rejected_without_writing(payload)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- reject empty or incomplete DNS results before publishing generated hosts files
- reject duplicate or unknown hostnames, non-IPv4 mappings, and the DNS failure sentinel
- add regression coverage for the validation boundary

`fetch_ips.py` can continue after a DNS failure and append `# IP Address Not Found` to an otherwise publishable result. This change validates the complete mapping list in `common.py` before `write_file` or `write_json_file` runs, so a partial result cannot overwrite the generated artifacts.

## Validation

- `python3 -m unittest discover -s tests -p 'test_*.py' -v`
- `python3 -m py_compile common.py fetch_ips.py update_ips.py tests/test_hosts_payload_validation.py`
- `git diff --check`
