### PR TITLE
fix: guard GitHub520 commit outcome

### DIFF
--- a/.github/workflows/GitHub520.yml
+++ b/.github/workflows/GitHub520.yml
@@ -35,10 +35,14 @@ jobs:
         git config --global user.email sunxuebangong@gmail.com
         git config --global user.name action_bot
         git add .
-        git commit -m "update readme content"
+        if git diff --cached --quiet; then
+          echo "No changes to commit"
+        else
+          git commit -m "update readme content"
+        fi
       continue-on-error: true
     - name: Check on failures
-      if: steps.commit.outputs.status == 'failure'
+      if: steps.commit.outcome == 'failure'
       run: exit 1
     - name: Push changes
       uses: ad-m/github-push-action@master


### PR DESCRIPTION
## Summary

- Treat an empty generated diff as a successful no-op instead of attempting an empty commit.
- Check `steps.commit.outcome` so a failed commit cannot be silently treated as success.

## Why

The workflow runs the commit step with `continue-on-error: true`, but checks the nonexistent `steps.commit.outputs.status` field. This leaves commit failures unobserved and allows the scheduled job to continue to the push step. The explicit no-change branch also avoids treating a normal empty update as a failed commit.

## Validation

- YAML parsing succeeds.
- Shell regression covers no-change, successful-change, and commit-failure paths.
- `git diff --check`
- `actionlint` diagnostics are unchanged baseline warnings for the existing v2 actions.
