### PR TITLE
fix: add lfs.github.com host rule

### DIFF
--- a/common.py
+++ b/common.py
@@ -30,6 +30,7 @@ GITHUB_URLS = [
     'githubstatus.com', 'live.github.com', 'media.githubusercontent.com',
     'objects.githubusercontent.com', 'pipelines.actions.githubusercontent.com',
     'raw.githubusercontent.com', 'user-images.githubusercontent.com',
+    'lfs.github.com',
     'vscode.dev', 'education.github.com', 'private-user-images.githubusercontent.com'
 ]
 


### PR DESCRIPTION
## Summary

- Add `lfs.github.com` to the canonical `GITHUB_URLS` source list.
- Ensure generated GitHub520 hosts output covers Git LFS connections.

## Context

Issue: https://github.com/521xueweihan/GitHub520/issues/301

The issue reports Git LFS uploads failing because `lfs.github.com` is intercepted. The hostname was absent from the source list, so generated hosts output could not include it.

## Validation

- AST regression assertion confirms the hostname is present and the source list remains unique.
- `python3 -m py_compile common.py`
- `git diff --check`
