### PR TITLE
fix: skip artifact writes when hosts are unchanged

### DIFF
--- a/common.py
+++ b/common.py
@@ -58,7 +58,6 @@ def write_file(hosts_content: str, update_time: str) -> bool:
     output_doc_file_path = os.path.join(os.path.dirname(__file__), "README.md")
     template_path = os.path.join(os.path.dirname(__file__),
                                  "README_template.md")
-    write_host_file(hosts_content)
     if os.path.exists(output_doc_file_path):
         with open(output_doc_file_path, "r") as old_readme_fb:
             old_content = old_readme_fb.read()
@@ -71,6 +70,7 @@ def write_file(hosts_content: str, update_time: str) -> bool:
                     print("host not change")
                     return False
 
+    write_host_file(hosts_content)
     with open(template_path, "r") as temp_fb:
         template_str = temp_fb.read()
         hosts_content = template_str.format(hosts_str=hosts_content,

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,0 +1,56 @@
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+import common
+
+
+class WriteFileTests(unittest.TestCase):
+    def test_unchanged_hosts_do_not_rewrite_any_artifact(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            hosts_content = "# GitHub520 Host Start\n1.2.3.4 github.com\n\n# Update time: old\n"
+            hosts = "before hosts"
+            (root / "README.md").write_text(
+                "prefix```bash\n"
+                f"{hosts_content.split('# Update time:')[0].strip()}\n"
+                "# Update time: previous\n```suffix",
+                encoding="utf-8",
+            )
+            (root / "README_template.md").write_text(
+                "{hosts_str}|{update_time}", encoding="utf-8"
+            )
+            (root / "hosts").write_text(hosts, encoding="utf-8")
+
+            with patch.object(common, "__file__", str(root / "common.py")):
+                changed = common.write_file(hosts_content, "new")
+
+            self.assertFalse(changed)
+            self.assertEqual((root / "README.md").read_text(encoding="utf-8"),
+                             "prefix```bash\n"
+                             f"{hosts_content.split('# Update time:')[0].strip()}\n"
+                             "# Update time: previous\n```suffix")
+            self.assertEqual((root / "hosts").read_text(encoding="utf-8"), hosts)
+
+    def test_changed_hosts_update_all_artifacts(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / "README.md").write_text(
+                "prefix```bash\nold host\n```suffix", encoding="utf-8"
+            )
+            (root / "README_template.md").write_text(
+                "{hosts_str}|{update_time}", encoding="utf-8"
+            )
+
+            hosts_content = "new host\n# Update time: now\n"
+            with patch.object(common, "__file__", str(root / "common.py")):
+                changed = common.write_file(hosts_content, "now")
+
+            self.assertTrue(changed)
+            self.assertEqual((root / "hosts").read_text(encoding="utf-8"), hosts_content)
+            self.assertIn(hosts_content, (root / "README.md").read_text(encoding="utf-8"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What does this PR do?

Avoid rewriting the generated hosts artifact before the no-op comparison, so the scheduled workflow does not create commits when the published hosts content is unchanged. Add regression tests for unchanged and changed artifact behavior.

## Why?

The repository TODO promises that unchanged hosts content will not update the generated files. The current write order rewrites `hosts` before comparing README content, while the workflow stages all files. This patch compares first and writes generated artifacts only after a real content change.

## Tests

- `PYTHONPATH=/tmp/github520-test-deps:$PWD python3 -m unittest discover -s tests -p 'test_*.py' -v`
- `python3 -m py_compile common.py update_ips.py fetch_ips.py`
- `git diff --check`